### PR TITLE
Switch to use the upstream source code of visit_struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unrealeased]
 - Moving from Catch2 v2 to v3 [#56](https://github.com/ami-iit/matio-cpp/pull/56)
 - Allowing input strings in vectors to be empty [#57](https://github.com/ami-iit/matio-cpp/pull/57)
+- Switch to use upstream repo of [`garbageslam/visit_struct`](https://github.com/garbageslam/visit_struct) instead of fork [`NikolausDemmel/visit_struct`](https://github.com/NikolausDemmel/visit_struct) [#58](https://github.com/ami-iit/matio-cpp/pull/58)
 
 ## [0.2.0] - 2022-04-28
 - Using a custom variable in InstallBasicPackageFile to backup the module path: [#47](https://github.com/ami-iit/matio-cpp/pull/47).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(visit_struct
       GIT_REPOSITORY https://github.com/ami-iit/visit_struct
-      GIT_TAG 969fc563477906432a9fcc91addf2c1e13c56f4c)
+      GIT_TAG 47bc6a3aa7588a1f4db39579a0b6812569a76b56)
 
     FetchContent_GetProperties(visit_struct)
     if(NOT visit_struct_POPULATED)


### PR DESCRIPTION
This PR switches to use a commit on the [`upstream` branch of `ami-iit`'s fork of `visit_struct`](https://github.com/ami-iit/visit_struct/tree/upstream). That branch is created by cherry-picking the CMake structured added in https://github.com/ami-iit/visit_struct/pull/1 on the top of the latest commit of the master branch of https://github.com/garbageslam/visit_struct, that got `VISITABLE_INIT` in https://github.com/garbageslam/visit_struct/pull/24/files . 

Using the upstream source code of `visit_struct` would simplify packaging the library in conda-forge . However, as far as I understood the code is different between https://github.com/garbageslam/visit_struct/pull/24/files and https://github.com/garbageslam/visit_struct/pull/14, so we may want to merge with care. The tests of `matio-cpp` are passing fine, but I do not know if there is something else we want to check before merging.