### PR TITLE
Fix type conversion for long in Windows and macOS systems

### DIFF
--- a/include/matioCpp/ConversionUtilities.h
+++ b/include/matioCpp/ConversionUtilities.h
@@ -71,9 +71,12 @@ template <> struct get_type<Logical>      { using type = uint8_t;     static inl
 
 // As explained in https://learn.microsoft.com/it-it/cpp/cpp/data-type-ranges?view=msvc-170 
 // and in https://www.ibm.com/docs/en/ibm-mq/8.0?topic=platforms-standard-data-types
-// In windows 64 bit a long has the same numbet of bytes of an int (4 byte = 32 bit)
+// In windows 64 bit a long has the same number of bytes of an int (4 byte = 32 bit)
+// In mcOS 64 bit a long has 8 bytes (8 byte = 64 bit)
 #ifdef _WIN32
 template <> struct get_type<long>         { using type = long;        static inline ValueType valueType(){return ValueType::INT32;};    static inline std::string toString() { return "long"; }; };
+#elif defined(__APPLE__)
+template <> struct get_type<long>         { using type = long;        static inline ValueType valueType(){return ValueType::INT64;};    static inline std::string toString() { return "long"; }; };
 #endif
 
 /**

--- a/include/matioCpp/ConversionUtilities.h
+++ b/include/matioCpp/ConversionUtilities.h
@@ -69,6 +69,13 @@ template <> struct get_type<char16_t>     { using type = char16_t;    static inl
 template <> struct get_type<char32_t>     { using type = char32_t;    static inline ValueType valueType(){return ValueType::UTF32;};    static inline std::string toString(){return "char32_t"          ;};};
 template <> struct get_type<Logical>      { using type = uint8_t;     static inline ValueType valueType(){return ValueType::LOGICAL;};  static inline std::string toString(){return "matioCpp::Logical" ;};};
 
+// As explained in https://learn.microsoft.com/it-it/cpp/cpp/data-type-ranges?view=msvc-170 
+// and in https://www.ibm.com/docs/en/ibm-mq/8.0?topic=platforms-standard-data-types
+// In windows 64 bit a long has the same numbet of bytes of an int (4 byte = 32 bit)
+#ifdef _WIN32
+template <> struct get_type<long>         { using type = long;        static inline ValueType valueType(){return ValueType::INT32;};    static inline std::string toString() { return "long"; }; };
+#endif
+
 /**
  * @brief Utility meta-function to check if a type is compatible with a std::string
  */

--- a/test/ExogenousConversionsUnitTest.cpp
+++ b/test/ExogenousConversionsUnitTest.cpp
@@ -44,13 +44,14 @@ struct testStruct
 {
     int i{1};
     double d{2.0};
+    long l{3};
     std::string s{"test"};
     std::vector<double> stdVec = {1.0, 2.0, 3.0, 4.0, 5.0};
     int* notSupported = nullptr;
     std::vector<std::string> stringVector = {"Huey", "Dewey", "Louie"};
     std::vector<bool> vecOfBool = {true, false, true};
 };
-VISITABLE_STRUCT(testStruct, i, d, s, stdVec, vecOfBool, stringVector);
+VISITABLE_STRUCT(testStruct, i, d, l, s, stdVec, vecOfBool, stringVector);
 
 
 struct nestedStruct
@@ -192,6 +193,7 @@ TEST_CASE("Exogenous conversions")
         matioCpp::Struct automaticStruct = matioCpp::make_variable("testStruct", s);
         REQUIRE(automaticStruct["i"].asElement<int>() == s.i);
         REQUIRE(automaticStruct["d"].asElement<double>() == s.d);
+        REQUIRE(automaticStruct["l"].asElement<long>() == s.l);
         REQUIRE(automaticStruct["s"].asString()() == s.s);
         checkSameVectors(automaticStruct["stdVec"].asVector<double>(), s.stdVec);
         checkSameVectors(automaticStruct["vecOfBool"].asVector<matioCpp::Logical>(), s.vecOfBool);
@@ -210,6 +212,7 @@ TEST_CASE("Exogenous conversions")
         checkSameVectors(s2.array, automaticNestedStruct["array"].asVector<float>());
         REQUIRE(automaticNestedStruct["s"].asStruct()["i"].asElement<int>() == s2.s.i);
         REQUIRE(automaticNestedStruct["s"].asStruct()["d"].asElement<double>() == s2.s.d);
+        REQUIRE(automaticNestedStruct["s"].asStruct()["l"].asElement<long>() == s2.s.l);
         REQUIRE(automaticNestedStruct["s"].asStruct()["s"].asString()() == s2.s.s);
         checkSameVectors(automaticNestedStruct["s"].asStruct()["stdVec"].asVector<double>(), s2.s.stdVec);
         checkSameVectors(automaticNestedStruct["s"].asStruct()["vecOfBool"].asVector<matioCpp::Logical>(), s2.s.vecOfBool);


### PR DESCRIPTION
As discussed in https://github.com/ami-iit/bipedal-locomotion-framework/issues/579 the long in windows has a different size with respect to the UNIX system indeed as explained:
1. https://learn.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=msvc-170
2. https://www.ibm.com/docs/en/ibm-mq/8.0?topic=platforms-standard-data-types 
3. https://learn.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=msvc-170#sizes-of-built-in-types

The `long` is a strange type since
|     |   Unix 32bit |  Unix 64bit | Windows 64bit   | 
|:---:|:---:|:---:|:---:|
| `int` | 4 bytes | 4 bytes | 4 bytes | 
| `long` | 4 bytes | 8 bytes | 4 bytes | 

Without this fix, we have the compilation error presented in https://github.com/robotology/robotology-superbuild/issues/1307#issue-1463849212

~I'm afraid we also have a similar error in macOS (see  https://github.com/robotology/robotology-superbuild/issues/1307#issue-1463849212). (This PR does not fix the problem for macOS)~

This fixes https://github.com/ami-iit/bipedal-locomotion-framework/issues/579 and unlocks the possibility to compile the YarpRobotLoggerDevice on windows


