### PR TITLE
Support finding visit_struct in the system also if it is installed without any CMake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,9 @@ install(TARGETS    matioCpp
 install(FILES "cmake/FindMATIO.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/matioCpp/cmake")
 file(COPY "cmake/FindMATIO.cmake" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/share/matioCpp/cmake")
 
+install(FILES "cmake/Findvisit_struct.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/matioCpp/cmake")
+file(COPY "cmake/Findvisit_struct.cmake" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/share/matioCpp/cmake")
+
 include(InstallBasicPackageFiles)
 
 install_basic_package_files(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 # Fetching visit_struct
 include(CMakeDependentOption)
 find_package(visit_struct QUIET)
-cmake_dependent_option(USE_SYSTEM_visit_struct "Use system visit_struct" ON "visit_struct_FOUND" OFF)
+option(USE_SYSTEM_visit_struct "Use system visit_struct" ${visit_struct_FOUND})
 if(USE_SYSTEM_visit_struct)
      find_package(visit_struct REQUIRED)
 else()

--- a/cmake/Findvisit_struct.cmake
+++ b/cmake/Findvisit_struct.cmake
@@ -1,0 +1,33 @@
+
+# - Try to find visit_struct
+#
+# The following are set after configuration is done:
+#  visit_struct_FOUND
+#
+# The following imported targets are created:
+#
+# visit_struct::visit_struct
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_package(visit_struct CONFIG QUIET)
+
+if(NOT visit_struct_FOUND)
+  find_path(VISIT_STRUCT_INCLUDE_DIR visit_struct/visit_struct_intrusive.hpp)
+  mark_as_advanced(VISIT_STRUCT_INCLUDE_DIR)
+  
+  if(VISIT_STRUCT_INCLUDE_DIR)
+    set(visit_struct_FOUND)
+  endif()
+endif()
+
+find_package_handle_standard_args(visit_struct DEFAULT_MSG visit_struct_FOUND)
+
+if(visit_struct_FOUND)
+    if(NOT TARGET visit_struct::visit_struct)
+      add_library(visit_struct::visit_struct INTERFACE IMPORTED)
+      set_target_properties(visit_struct::visit_struct PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${VISIT_STRUCT_INCLUDE_DIR}")
+    endif()
+endif()

--- a/cmake/Findvisit_struct.cmake
+++ b/cmake/Findvisit_struct.cmake
@@ -16,9 +16,9 @@ find_package(visit_struct CONFIG QUIET)
 if(NOT visit_struct_FOUND)
   find_path(VISIT_STRUCT_INCLUDE_DIR visit_struct/visit_struct_intrusive.hpp)
   mark_as_advanced(VISIT_STRUCT_INCLUDE_DIR)
-  
+
   if(VISIT_STRUCT_INCLUDE_DIR)
-    set(visit_struct_FOUND)
+    set(visit_struct_FOUND TRUE)
   endif()
 endif()
 


### PR DESCRIPTION
This PR permits to build matio-cpp when visit_struct is installed, but no CMake config for it is installed (for example as it happens when visit_struct is installed via vcpkg or by manually copying the headers).

Furthermore, I also fixed the logic of `USE_SYSTEM_visit_struct`, as as it was before this PR, even if the user explicitly set `USE_SYSTEM_visit_struct`, the build silently went back to the `USE_SYSTEM_visit_struct` set to `OFF` case, instead of giving an error.