### PR TITLE
Remove use of brew from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     steps:
@@ -31,20 +31,11 @@ jobs:
 
     # Remove apt repos that are known to break from time to time
     # See https://github.com/actions/virtual-environments/issues/323
-    - name: Remove broken apt repos [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+    - name: Remove broken apt repos
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-
-    - name: Dependencies [macOS]
-      if: matrix.os == 'macOS-latest'
-      run: |
-        brew update
-        brew install libmatio eigen
-
-    - name: Dependencies [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+    - name: Dependencies
       run: |
         sudo apt-get update
         sudo apt-get install libmatio-dev valgrind libeigen3-dev
@@ -77,9 +68,7 @@ jobs:
     # CMAKE-BASED PROJECT
     # ===================
 
-
-    - name: Configure [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+    - name: Configure
       shell: bash
       run: |
         mkdir -p build
@@ -88,16 +77,6 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
               -DBUILD_TESTING:BOOL=ON \
               -DFRAMEWORK_RUN_Valgrind_tests:BOOL=ON ..
-
-    - name: Configure [macOS]
-      if: matrix.os == 'macOS-latest'
-      shell: bash
-      run: |
-        mkdir -p build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
-              -DBUILD_TESTING:BOOL=ON ..
 
     - name: Build
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+- Remove use of brew from CI [#76](https://github.com/ami-iit/matio-cpp/pull/76)
+- 
+## [0.2.3] - 2023-11-15
 - Added example. It is tested in CI. [#67](https://github.com/ami-iit/matio-cpp/pull/67)
 - Clarify how to install matio with conda-forge [#68](https://github.com/ami-iit/matio-cpp/pull/68)
 - Support finding visit_struct in the system also if it is installed without any CMake config file [#70](https://github.com/ami-iit/matio-cpp/pull/70)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ It can be used for reading and writing binary MATLAB `.mat` files from C++, with
 
 The depencies are [``CMake``](https://cmake.org/) (minimum version 3.10) and [``matio``](https://github.com/tbeu/matio). While we suggest to follow the build instructions provided in the [``matio`` home page](https://github.com/tbeu/matio), it can also installed from common package managers:
 - Linux: ``sudo apt install libmatio-dev``
-- macOS: ``brew install libmatio``
-- Windows (but also Linux and macOS), via [``conda-forge``](https://conda-forge.org/): ``mamba install -c conda-forge libmatio``
+- Linux, macOS, Windows, via [``conda-forge``](https://conda-forge.org/): ``mamba install -c conda-forge libmatio``
 
 [`Eigen`](https://eigen.tuxfamily.org/index.php) is an optional dependency. If available, some conversions are defined.
 


### PR DESCRIPTION
``brew`` CI has started to fail. Since we test the ``macOS`` case in ``conda``, I think we can remove this use case.